### PR TITLE
Fix: fix bug for not play audio after end of entry

### DIFF
--- a/src/lib/AudioRecorder.js
+++ b/src/lib/AudioRecorder.js
@@ -42,7 +42,6 @@ class AudioRecorder {
     this.processor.disconnect()
     this.processor.onaudioprocess = null
     this.processor = null
-    this.stream.getTracks().forEach(track => track.stop())
     this.stream = null
     clearInterval(this.slicing)
   }


### PR DESCRIPTION
## Bug

- No audio is played after end of entry on iOS Safari
  - it is might bug of `microphoneStreamTrack.stop()` and Web Audio API
